### PR TITLE
Enhance file management on fileshare

### DIFF
--- a/scripts/generate_file_sas_url.py
+++ b/scripts/generate_file_sas_url.py
@@ -9,18 +9,14 @@ from azure_client import AzureClient
 
 def generate_file_sas_url():
     parser = argparse.ArgumentParser()
-    parser.add_argument("project_name", help="Project name.")
-    parser.add_argument("run_name", help="Run name.")
-    parser.add_argument("data_type", help="Run data type: processed_data or raw_data.")
+    parser.add_argument("dir_path", help="Directory path in the file storage.")
     parser.add_argument("file_name", help="File name.")
     args = parser.parse_args()
 
     azure_client = AzureClient()
 
     url = azure_client.generate_run_data_sas_url(
-        project_name=args.project_name,
-        run_name=args.run_name,
-        data_type=args.data_type,
+        dir_path=args.dir_path,
         file_name=args.file_name,
         is_admin=True,
     )

--- a/tests/test_azure_client.py
+++ b/tests/test_azure_client.py
@@ -7,13 +7,17 @@ import pytest
 from azure.core.exceptions import ResourceNotFoundError
 from pytest import MonkeyPatch
 
+from auth import Project, User
 from azure_client import (
     AzureClient,
     AzureVMDeploymentProperties,
     DeploymentNotFound,
+    IncorrectDataFilePath,
     ProjectFile,
     VMNotFound,
     _project_name_to_vm_name,
+    validate_project_document_file_path,
+    validate_run_data_file_path,
     wait_for_deployment_completeness,
 )
 
@@ -215,8 +219,39 @@ def test_get_run_files_with_prefix(client: AzureClient, monkeypatch: MonkeyPatch
         assert len(list(files)) == 1
 
 
-@patch("azure_client._get_projects_path")
 def test_generate_project_documents_sas_url(
+    client: AzureClient,
+    monkeypatch: MonkeyPatch,
+):
+    with patch.object(
+        client, "_file_shared_access_signature"
+    ) as file_shared_access_signature_mock:
+        file_shared_access_signature_mock.generate_file.return_value = "params=params"
+        monkeypatch.setenv("AZURE_STORAGE_FILESHARE", "fileshare")
+        monkeypatch.setenv("AZURE_STORAGE_ACCOUNT", "storage")
+
+        url = client.generate_project_documents_sas_url(
+            dir_path="dir_path",
+            file_name="hello.txt",
+        )
+
+    # pylint: disable=line-too-long
+    assert (
+        url
+        == "https://storageaccount.file.core.windows.net/fileshare/dir_path/hello.txt?params=params"
+    )
+    mock_kwargs = file_shared_access_signature_mock.generate_file.call_args.kwargs
+    assert mock_kwargs["share_name"] == "fileshare"
+    assert mock_kwargs["directory_name"] == "dir_path"
+    assert mock_kwargs["file_name"] == "hello.txt"
+    assert mock_kwargs["permission"].read is True
+    assert mock_kwargs["permission"].delete is True
+    assert mock_kwargs["permission"].create is False
+    assert mock_kwargs["permission"].write is False
+
+
+@patch("azure_client._get_projects_path")
+def test_generate_project_documents_upload_sas_url(
     _get_projects_path_mock: MagicMock,
     client: AzureClient,
     monkeypatch: MonkeyPatch,
@@ -227,9 +262,9 @@ def test_generate_project_documents_sas_url(
         file_shared_access_signature_mock.generate_file.return_value = "params=params"
         monkeypatch.setenv("AZURE_STORAGE_FILESHARE", "fileshare")
         monkeypatch.setenv("AZURE_STORAGE_ACCOUNT", "storage")
-        _get_projects_path_mock.return_value = "dir_path"
+        _get_projects_path_mock.return_value = "projects"
 
-        url = client.generate_project_documents_sas_url(
+        url = client.generate_project_documents_upload_sas_url(
             project_name="project",
             file_name="hello.txt",
         )
@@ -237,15 +272,15 @@ def test_generate_project_documents_sas_url(
     # pylint: disable=line-too-long
     assert (
         url
-        == "https://storageaccount.file.core.windows.net/fileshare/dir_path/project/documents/hello.txt?params=params"
+        == "https://storageaccount.file.core.windows.net/fileshare/projects/project/documents/hello.txt?params=params"
     )
     mock_kwargs = file_shared_access_signature_mock.generate_file.call_args.kwargs
     assert mock_kwargs["share_name"] == "fileshare"
-    assert mock_kwargs["directory_name"] == "dir_path/project/documents"
+    assert mock_kwargs["directory_name"] == "projects/project/documents"
     assert mock_kwargs["file_name"] == "hello.txt"
-    assert mock_kwargs["permission"].read is True
+    assert mock_kwargs["permission"].read is False
+    assert mock_kwargs["permission"].delete is False
     assert mock_kwargs["permission"].create is True
-    assert mock_kwargs["permission"].delete is True
     assert mock_kwargs["permission"].write is True
 
 
@@ -253,9 +288,7 @@ def test_generate_project_documents_sas_url(
     ("is_admin"),
     (True, False),
 )
-@patch("azure_client._get_run_data_directory_name")
 def test_generate_run_data_sas_url(
-    get_run_data_directory_name_mock: MagicMock,
     client: AzureClient,
     monkeypatch: MonkeyPatch,
     is_admin: bool,
@@ -266,12 +299,9 @@ def test_generate_run_data_sas_url(
         file_shared_access_signature_mock.generate_file.return_value = "params=params"
         monkeypatch.setenv("AZURE_STORAGE_FILESHARE", "fileshare")
         monkeypatch.setenv("AZURE_STORAGE_ACCOUNT", "storage")
-        get_run_data_directory_name_mock.return_value = "dir_path"
 
         url = client.generate_run_data_sas_url(
-            project_name="project",
-            run_name="run",
-            data_type="processed_data",
+            dir_path="dir_path",
             file_name="hello.txt",
             is_admin=is_admin,
         )
@@ -292,7 +322,7 @@ def test_generate_run_data_sas_url(
 
 @patch("azure_client.ShareDirectoryClient")
 @patch("azure_client.ShareFileClient")
-def test_list_files_recursive(
+def test_list_files_recursive_without_detailed_info(
     share_file_client: MagicMock,
     share_directory_client: MagicMock,
     client: AzureClient,
@@ -300,12 +330,58 @@ def test_list_files_recursive(
 ):
     monkeypatch.setenv("AZURE_STORAGE_FILESHARE", "fileshare")
     files_and_folders__root = [
-        {"name": "file-1.txt", "is_directory": False},
+        {"name": "file-1.txt", "is_directory": False, "size": 123},
         {"name": "directory-1", "is_directory": True},
     ]
     files_and_folders__dir_1 = [
-        {"name": "file-2.txt", "is_directory": False},
-        {"name": "file-3.txt", "is_directory": False},
+        {"name": "file-2.txt", "is_directory": False, "size": 124},
+        {"name": "file-3.txt", "is_directory": False, "size": 456},
+    ]
+    share_directory_client.from_connection_string.return_value = share_directory_client
+    share_file_client.from_connection_string.return_value = share_file_client
+
+    share_directory_client.list_directories_and_files.side_effect = [
+        files_and_folders__root,
+        files_and_folders__dir_1,
+    ]
+
+    files = client._list_files_recursive(dir_path="/")
+    files_list = list(files)
+
+    assert len(files_list) == 3
+    assert all(isinstance(file, ProjectFile) for file in files_list)
+    assert len(share_directory_client.list_directories_and_files.call_args) == 2
+    assert (
+        share_directory_client.from_connection_string.call_args_list[0][1][
+            "directory_path"
+        ]
+        == "/"
+    )
+    assert (
+        share_directory_client.from_connection_string.call_args_list[1][1][
+            "directory_path"
+        ]
+        == "/directory-1"
+    )
+    assert all(file.last_modified is None for file in files_list)
+
+
+@patch("azure_client.ShareDirectoryClient")
+@patch("azure_client.ShareFileClient")
+def test_list_files_recursive_with_detailed_info(
+    share_file_client: MagicMock,
+    share_directory_client: MagicMock,
+    client: AzureClient,
+    monkeypatch: MonkeyPatch,
+):
+    monkeypatch.setenv("AZURE_STORAGE_FILESHARE", "fileshare")
+    files_and_folders__root = [
+        {"name": "file-1.txt", "is_directory": False, "size": 123},
+        {"name": "directory-1", "is_directory": True},
+    ]
+    files_and_folders__dir_1 = [
+        {"name": "file-2.txt", "is_directory": False, "size": 124},
+        {"name": "file-3.txt", "is_directory": False, "size": 456},
     ]
     share_directory_client.from_connection_string.return_value = share_directory_client
     share_file_client.from_connection_string.return_value = share_file_client
@@ -335,12 +411,11 @@ def test_list_files_recursive(
         },
     ]
 
-    files = client._list_files_recursive(dir_path="/")
+    files = client._list_files_recursive(dir_path="/", fetch_detailed_information=True)
     files_list = list(files)
 
     assert len(files_list) == 3
     assert all(isinstance(file, ProjectFile) for file in files_list)
-    assert len(share_directory_client.list_directories_and_files.call_args) == 2
     assert len(share_directory_client.list_directories_and_files.call_args) == 2
     assert (
         share_directory_client.from_connection_string.call_args_list[0][1][
@@ -354,3 +429,51 @@ def test_list_files_recursive(
         ]
         == "/directory-1"
     )
+
+
+@patch("azure_client._get_projects_path", MagicMock(return_value="projects"))
+@pytest.mark.parametrize(
+    ("path,is_valid"),
+    (
+        ("projects/hello/runs/world/raw_data/", True),
+        ("projects/hello/runs/world/processed_data/", True),
+        ("projects/hello/runs/world/processed_data/and/the/path", True),
+        ("projects/otherproject/runs/world/processed_data/", False),
+        ("projects/hello/notruns/world/processed_data/", False),
+        ("projects/hel|lo/runs/world/processed_data/", False),
+        ("projects/hello/runs/wor|ld/processed_data/", False),
+        ("start/differently/hello/runs/world/processed_data/", False),
+        ("projects/hello/runs/world/other_data/", False),
+    ),
+)
+def test_validate_run_data_file_path(path, is_valid):
+    is_invalid = False
+    try:
+        validate_run_data_file_path(
+            path, User(id=1, is_admin=False, projects=[Project(id=2, name="hello")])
+        )
+    except IncorrectDataFilePath:
+        is_invalid = True
+    assert is_valid is not is_invalid
+
+
+@patch("azure_client._get_projects_path", MagicMock(return_value="projects"))
+@pytest.mark.parametrize(
+    ("path,is_valid"),
+    (
+        ("projects/hello/documents/", True),
+        ("projects/hello/world/documents/and/the/path", False),
+        ("projects/otherproject/documents/", False),
+        ("projects/hel|lo/documents/", False),
+        ("start/differently/hello/documents/", False),
+    ),
+)
+def test_validate_document_file_path(path, is_valid):
+    is_invalid = False
+    try:
+        validate_project_document_file_path(
+            path, User(id=1, is_admin=False, projects=[Project(id=2, name="hello")])
+        )
+    except IncorrectDataFilePath:
+        is_invalid = True
+    assert is_valid is not is_invalid


### PR DESCRIPTION
- fixes never ending requests on run data due to extra requests
- fixes sas url bug for data in sub folders

pour les fichiers de données des Runs, on ne récupère pas les données supplémentaires (ça évite une requette supplémentaire par fichier, ce qui faisait que les données que Quentin avait uploadé ne s'affiche pas) - il manque juste la date de modification comparé à avant.
pour la génération des URLs présignés, on passe directement le path du fichier plutôt que d'envyer le nom du projet, du run, etc dans l'URL. Le path est validé directement