### PR TITLE
feature/kill no connection

### DIFF
--- a/clients/guacamole/client.py
+++ b/clients/guacamole/client.py
@@ -197,6 +197,7 @@ class GuacamoleClient:
         time_unused: timedelta = timedelta(minutes=30),
         skip_groups: list[str] | None = None,
         from_date: datetime | None = None,
+        kill_no_connection: bool = False,
     ) -> list[str]:
         """
         Check all existing VM connections to see
@@ -240,6 +241,10 @@ class GuacamoleClient:
                 if connection.active_connections > 0:
                     # There is currently someone connected
                     continue
+
+                if kill_no_connection and connection.last_active is None:
+                    # Nobody has been connected to this VM, but we want to kill it anyway
+                    projects_to_shutdown.append(connection.name)
 
                 if connection.last_active is None:
                     # Nobody has been connected to this VM

--- a/cron.json
+++ b/cron.json
@@ -7,6 +7,10 @@
     {
       "command": "*/30 * * * * python -m scripts.check_health",
       "size": "S"
+    },
+    {
+      "command": "0 0 * * * python -m scripts.kill_unused_vm --no_connection",
+      "size": "S"
     }
   ]
 }

--- a/scripts/kill_unused_vm.py
+++ b/scripts/kill_unused_vm.py
@@ -23,6 +23,7 @@ async def kill_unused_vm():
         "--no-connection",
         dest="no_connection",
         help="Will kill VM that have not seen a connection",
+        action="store_true",
     )
     args = parser.parse_args()
 

--- a/scripts/kill_unused_vm.py
+++ b/scripts/kill_unused_vm.py
@@ -4,9 +4,9 @@ Check if there is VM without a connected user for more than 30min.
 If those VM are not in a group to indicate that it should be kept awake,
 shut it down and destroy the connection in Guacamole
 """
+import argparse
 import asyncio
 from typing import Any, Coroutine
-import argparse
 
 from clients.guacamole import GuacamoleClient
 from scripts.delete_vm import delete_vm

--- a/tests/clients/test_guacamole_client.py
+++ b/tests/clients/test_guacamole_client.py
@@ -217,3 +217,10 @@ def test_vm_to_shutdown(client: GuacamoleClient):
                 skip_groups=["default"], from_date=fake_now_before_shutdown
             )
             assert projects_to_shutdown == []
+
+            projects_to_shutdown = client.get_vm_to_shutdown(
+                skip_groups=["default"],
+                from_date=fake_now_before_shutdown,
+                kill_no_connection=True,
+            )
+            assert projects_to_shutdown == ["update-setup-clone"]


### PR DESCRIPTION
Add an option to the kill_unused_vm scripts to force shutting down VM that have never been connected to.