### PR TITLE
feat: add project images routes

### DIFF
--- a/tests/api/test_images.py
+++ b/tests/api/test_images.py
@@ -25,8 +25,8 @@ def override_dependencies(app: FastAPI, image_storage_client: ImageStorageClient
 def test_list_project_object_images(
     client: TestClient, image_storage_client, override_dependencies
 ):
-    image_storage_client.list_project_object_images.return_value = AsyncMock()
-    image_storage_client.list_project_object_images.return_value.__aiter__.return_value = [
+    image_storage_client.list_project_images.return_value = AsyncMock()
+    image_storage_client.list_project_images.return_value.__aiter__.return_value = [
         "image1.png",
         "image2.jpg",
     ]
@@ -40,7 +40,7 @@ def test_list_project_object_images(
 def test_get_upload_signed_url_valid_extension(
     client: TestClient, image_storage_client, override_dependencies
 ):
-    image_storage_client.generate_signed_upload_project_object_image_url.return_value = (
+    image_storage_client.generate_signed_upload_project_image_url.return_value = (
         "http://signed.url"
     )
 


### PR DESCRIPTION
- Added a new route to retrieve project images.
- Modified the existing route to retrieve object group images.
- Updated the corresponding tests.

fix: add await in set_blob_cors script

- Added 'await' keyword in the set_blob_cors script to ensure proper execution.

refactor: rename methods in ImageStorageClient

- Renamed 'list_project_object_images' to 'list_project_images'.
- Renamed 'generate_signed_upload_project_object_image_url' to 'generate_signed_upload_project_image_url'.
- Updated the method calls in the codebase.

chore: update dependencies

- Updated the dependency 'azure-keyvault-secrets' to version 4.9.0.