### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -3,6 +3,9 @@
 # branches.
 name: update-caches
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/betagouv/euphrosyne-tools-api/security/code-scanning/1](https://github.com/betagouv/euphrosyne-tools-api/security/code-scanning/1)

In general, the fix is to explicitly declare `permissions` for the workflow or for the specific job so that the `GITHUB_TOKEN` has only the minimal rights needed. For this workflow, the steps only need to read the repository contents (for `actions/checkout`), and the cache actions operate via GitHub’s cache APIs that work with a token that only requires `contents: read` (they don’t modify repository content). Therefore, we can safely set `permissions: contents: read` at the workflow root, which will apply to all jobs, including `build-cache`.

The best fix without changing functionality is to add a top-level `permissions:` block right after `name: update-caches`. This keeps the job definition untouched while constraining the default permissions for the entire workflow. Concretely, edit `.github/workflows/update-caches.yml` to insert:

```yaml
permissions:
  contents: read
```

after line 4 (`name: update-caches`). No additional imports or methods are required; this is purely a YAML configuration change within the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
