### PR TITLE
Add AbstractDataClient and shared data models

### DIFF
--- a/api/data.py
+++ b/api/data.py
@@ -21,12 +21,12 @@ from clients.azure.data import (
     FolderCreationError,
     IncorrectDataFilePath,
     ProjectDocumentsNotFound,
-    ProjectFileOrDirectory,
     RunDataNotFound,
+    extract_info_from_path,
     validate_project_document_file_path,
     validate_run_data_file_path,
-    extract_info_from_path,
 )
+from clients.data_models import ProjectFileOrDirectory
 from clients.azure.stream import stream_zip_from_azure_files_async
 from dependencies import get_storage_azure_client
 from hooks.euphrosyne import post_data_access_event

--- a/clients/data_client.py
+++ b/clients/data_client.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import abc
+import io
+from typing import AsyncIterator
+
+from .data_models import ProjectFileOrDirectory, RunDataTypeType, SASCredentials
+
+
+class AbstractDataClient(abc.ABC):
+    @abc.abstractmethod
+    def list_project_dirs(self) -> list[str]:
+        """Returns all directory names in project folder."""
+
+    @abc.abstractmethod
+    def get_project_documents(
+        self,
+        project_name: str,
+    ) -> list[ProjectFileOrDirectory]:
+        """Return the list of files/directories under a project's documents folder."""
+
+    @abc.abstractmethod
+    def get_run_files_folders(
+        self,
+        project_name: str,
+        run_name: str,
+        data_type: RunDataTypeType,
+        folder: str | None,
+    ) -> list[ProjectFileOrDirectory]:
+        """Return run data files and folders for a given run."""
+
+    @abc.abstractmethod
+    def iter_project_run_files_async(
+        self,
+        project_name: str,
+        run_name: str,
+        data_type: RunDataTypeType | None = None,
+    ) -> AsyncIterator[
+        object
+    ]:  # TODO : add better typing than object. We have to check what methods is needed.
+        """Yield run files for streaming (provider-specific downloaders)."""
+
+    @abc.abstractmethod
+    def download_run_file(
+        self,
+        filepath: str,
+    ) -> io.BytesIO:
+        """Return a downloader/file-like object for a run file."""
+
+    @abc.abstractmethod
+    def is_project_data_available(self, project_name: str) -> bool:
+        """Check if project data is available on the data backend."""
+
+    @abc.abstractmethod
+    def generate_run_data_upload_sas(
+        self,
+        project_name: str,
+        run_name: str,
+        data_type: RunDataTypeType | None = None,
+    ) -> SASCredentials:
+        """Generate credentials used to upload run data."""
+
+    @abc.abstractmethod
+    def generate_run_data_sas_url(
+        self,
+        dir_path: str,
+        file_name: str,
+        is_admin: bool,
+    ) -> str:
+        """Generate a signed URL to manage run data."""
+
+    @abc.abstractmethod
+    def generate_project_documents_upload_sas_url(
+        self, project_name: str, file_name: str
+    ) -> str:
+        """Generate a signed URL to upload project documents."""
+
+    @abc.abstractmethod
+    def generate_project_documents_sas_url(self, dir_path: str, file_name: str) -> str:
+        """Generate a signed URL to download/delete project documents."""
+
+    @abc.abstractmethod
+    def init_project_directory(self, project_name: str):
+        """Create the project directory with default subfolders."""
+
+    @abc.abstractmethod
+    def init_run_directory(self, run_name: str, project_name: str) -> None:
+        """Create the run directory with default subfolders."""
+
+    @abc.abstractmethod
+    def rename_project_directory(self, project_name: str, new_name: str) -> None:
+        """Rename the project directory."""
+
+    @abc.abstractmethod
+    def rename_run_directory(
+        self, run_name: str, project_name: str, new_name: str
+    ) -> None:
+        """Rename the run directory."""

--- a/clients/data_models.py
+++ b/clients/data_models.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal, TypedDict
+
+from pydantic import BaseModel
+
+RunDataTypeType = Literal["processed_data", "raw_data", "HDF5"]
+
+
+class ProjectFile(BaseModel):
+    name: str
+    last_modified: datetime | None = None
+    size: int
+    path: str
+
+
+class ProjectFileOrDirectory(BaseModel):
+    name: str
+    last_modified: datetime | None = None
+    size: int | None
+    path: str
+    type: Literal["file", "directory"]
+
+
+class SASCredentials(TypedDict):
+    url: str
+    token: str

--- a/tests/clients/test_azure_data_client.py
+++ b/tests/clients/test_azure_data_client.py
@@ -14,11 +14,11 @@ from clients.azure import DataAzureClient
 from clients.azure.data import (
     FolderCreationError,
     IncorrectDataFilePath,
-    ProjectFile,
     extract_info_from_path,
     validate_project_document_file_path,
     validate_run_data_file_path,
 )
+from clients.data_models import ProjectFile
 from ..mocks.azure import factories as azure_factories
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -8,7 +8,8 @@ from fastapi.testclient import TestClient
 from auth import User, get_current_user
 from backgrounds import wait_for_deploy
 from clients.azure import VMAzureClient
-from clients.azure.data import IncorrectDataFilePath, ProjectFileOrDirectory
+from clients.azure.data import IncorrectDataFilePath
+from clients.data_models import ProjectFileOrDirectory
 from clients.azure.vm import AzureVMDeploymentProperties, DeploymentNotFound, VMNotFound
 from clients.guacamole import GuacamoleClient, GuacamoleConnectionNotFound
 from dependencies import (


### PR DESCRIPTION
### Motivation
- Provide a provider-agnostic data client interface so different storage backends can be implemented consistently using a common contract.
- Centralize data types to remove duplicated model definitions and ensure a single source of truth for data-related schemas.
- Make the Azure data client conform to the new interface and reuse shared models to simplify API surface and tests.

### Description
- Added `clients/data_models.py` containing `RunDataTypeType`, `ProjectFile`, `ProjectFileOrDirectory`, and `SASCredentials` shared models.
- Added `clients/data_client.py` introducing the `AbstractDataClient` interface with methods such as `list_project_dirs`, `get_project_documents`, `iter_project_run_files_async`, and SAS URL/credential generators.
- Updated `clients/azure/data.py` to import and use the shared models and to implement `AbstractDataClient` (changed `DataAzureClient` signature) while removing local duplicate model definitions.
- Adjusted imports in `api/data.py` and tests (`tests/test_main.py`, `tests/clients/test_azure_data_client.py`) to reference `clients.data_models` instead of the removed local types.

### Testing
- No automated tests were executed as part of this change.
- Tests were updated to import the shared models (`tests/clients/test_azure_data_client.py` and `tests/test_main.py`) but the test suite was not run.
- No test failures or successes to report because automated tests were not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6965139fcec0832991817e2689a8ebac)